### PR TITLE
fix(filters): prevent array out-of-bounds access

### DIFF
--- a/addons/sourcemod/scripting/ZLeader.sp
+++ b/addons/sourcemod/scripting/ZLeader.sp
@@ -2528,7 +2528,7 @@ stock bool IsValidHex(char[] arg) {
 ============================================================================ */
 public bool Filter_Leaders(const char[] sPattern, Handle hClients) {
 	for (int i = 1; i <= MaxClients; i++) {
-		if (IsClientInGame(i) && !IsFakeClient(i) && (IsPossibleLeader(i) || g_iCurrentLeader[i]))
+		if (IsClientInGame(i) && !IsFakeClient(i) && (IsPossibleLeader(i) || (i < MAXLEADER && g_iCurrentLeader[i])))
 			PushArrayCell(hClients, i);
 	}
 	return true;
@@ -2536,7 +2536,7 @@ public bool Filter_Leaders(const char[] sPattern, Handle hClients) {
 
 public bool Filter_NotLeaders(const char[] sPattern, Handle hClients) {
 	for (int i = 1; i <= MaxClients; i++) {
-		if (IsClientInGame(i) && !IsFakeClient(i) && !IsPossibleLeader(i) && !g_iCurrentLeader[i])
+		if (IsClientInGame(i) && !IsFakeClient(i) && !IsPossibleLeader(i) && (i >= MAXLEADER || !g_iCurrentLeader[i]))
 			PushArrayCell(hClients, i);
 	}
 	return true;
@@ -2544,7 +2544,7 @@ public bool Filter_NotLeaders(const char[] sPattern, Handle hClients) {
 
 public bool Filter_Leader(const char[] sPattern, Handle hClients) {
 	for (int i = 1; i <= MaxClients; i++) {
-		if (IsValidClient(i) && i < sizeof(g_iCurrentLeader) && g_iCurrentLeader[i])
+		if (IsValidClient(i) && i < MAXLEADER && g_iCurrentLeader[i])
 			PushArrayCell(hClients, i);
 	}
 	return true;
@@ -2552,7 +2552,7 @@ public bool Filter_Leader(const char[] sPattern, Handle hClients) {
 
 public bool Filter_NotLeader(const char[] sPattern, Handle hClients) {
 	for (int i = 1; i <= MaxClients; i++) {
-		if (IsValidClient(i) && !g_iCurrentLeader[i])
+		if (IsValidClient(i) && (i >= MAXLEADER || !g_iCurrentLeader[i]))
 			PushArrayCell(hClients, i);
 	}
 	return true;

--- a/addons/sourcemod/scripting/include/zleader.inc
+++ b/addons/sourcemod/scripting/include/zleader.inc
@@ -5,7 +5,7 @@
 
 #define ZLeader_V_MAJOR   "3"
 #define ZLeader_V_MINOR   "6"
-#define ZLeader_V_PATCH   "5"
+#define ZLeader_V_PATCH   "6"
 
 #define ZLeader_VERSION   ZLeader_V_MAJOR..."."...ZLeader_V_MINOR..."."...ZLeader_V_PATCH
 


### PR DESCRIPTION
## Description
This PR fixes potential array out-of-bounds access in the leader filter functions.
The issue occurred when trying to access `g_iCurrentLeader` array with client indices that could be larger than the array size.

## Changes
- Added proper bounds checking in all filter functions:
  - `Filter_Leaders`
  - `Filter_NotLeaders`
  - `Filter_Leader`
  - `Filter_NotLeader`
- Standardized array bounds checking using `MAXLEADER` constant
- Improved safety by handling client indices >= MAXLEADER appropriately

## Technical Details
- The `g_iCurrentLeader` array is sized to `MAXLEADER`
- Client indices can go up to `MaxClients`
- Added checks to prevent accessing the array with invalid indices
- For indices >= MAXLEADER, clients are considered "not leaders" by default

## Testing
- Verified all filter functions work correctly with client indices
- Confirmed no array out-of-bounds errors occur
- Tested with various client indices including edge cases